### PR TITLE
Prepare Local Vision SEO for Netlify deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Local Vision SEO currently has no required runtime secrets.
+# These optional values are useful for local and Netlify production builds.
+
+JEKYLL_ENV=production
+SITE_URL=https://example.com

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,11 @@
+# Netlify deployment handoff
+
+This repository is a static Jekyll site built with the Minimal Mistakes theme.
+
+## Recommended Netlify settings
+- Build command: `bundle exec jekyll build`
+- Publish directory: `_site`
+- Build environment: `JEKYLL_ENV=production`
+
+## Continuous deploy note
+The current ChatGPT-connected Netlify tool surface supports project creation and deploy inspection, but it does not expose direct GitHub repository linking. Complete the one-time GitHub linking step in Netlify, then use normal pushes and pull requests to trigger future builds.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "bundle exec jekyll build"
+  publish = "_site"
+
+[build.environment]
+  JEKYLL_ENV = "production"


### PR DESCRIPTION
## Summary
- add `netlify.toml` with Jekyll build and publish settings
- add `.env.example` documenting optional deploy values
- add `DEPLOYMENT.md` with Netlify handoff notes

## Notes
- The existing `README.md` still reflects the upstream Minimal Mistakes theme.
- I attempted to refresh `README.md`, but the currently exposed GitHub file-write action rejected updating an existing file even after indicating that it expected a blob SHA. I left the README unchanged and added `DEPLOYMENT.md` instead so the deployment guidance still lands in the repo.

## Deploy implications
- Netlify project can be created from ChatGPT tools.
- Direct GitHub repo linking is not exposed in the current Netlify manifest, so a one-time manual repo-link step is still required for continuous deploys.
